### PR TITLE
Add support for MIDI ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The `MB::Sound::JackFFI` class represents a connection to a JACK server with a
 specific client name.  Its `input` and `output` instance methods will create
 input or output ports on the JACK client.
 
+### Audio
+
 ```ruby
 require 'mb-sound-jackffi' # Or 'mb/sound/jack_ffi'
 
@@ -55,6 +57,10 @@ end
 ```
 
 Also check out `bin/passthrough.rb` and `bin/invert.rb`.
+
+### MIDI
+
+Check out `bin/midi_thru.rb` and `bin/midi_invert.rb`.
 
 ## Testing
 

--- a/bin/midi_invert.rb
+++ b/bin/midi_invert.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+# Passes MIDI data through, with velocities, note numbers, pitch bend, and CC
+# values reversed (unless multiple events are delivered at the same time).
+#
+# Example: ./bin/midi_invert.rb
+# Example: ./bin/midi_invert.rb jack-keyboard:midi_out zynaddsubfx:midi_input
+
+require 'bundler/setup'
+require 'mb-sound-jackffi'
+
+jack = MB::Sound::JackFFI[]
+
+input = jack.input(port_type: :midi, port_names: ['midi_in'], connect: ARGV[0])
+output = jack.output(port_type: :midi, port_names: ['midi_out'], connect: ARGV[1])
+
+loop do
+  event = input.read[0]
+
+  if event.length == 3
+    bytes = event.bytes
+    case bytes[0]
+    when 0x80, 0x90
+      # Note On/Note Off
+      bytes[1] = 127 - bytes[1] # Note number
+      bytes[2] = 127 - bytes[2] # Velocity
+
+    when 0xe0
+      # Pitch bend
+      bytes[1] = 127 - bytes[1] # Note number
+      bytes[2] = 127 - bytes[2] # Velocity
+
+    when 0xb0
+      # CC
+      bytes[2] = 127 - bytes[2] # CC value
+    end
+
+    event = bytes.pack('C*')
+  end
+
+  puts event.bytes.inspect
+  output.write([event])
+end

--- a/bin/midi_thru.rb
+++ b/bin/midi_thru.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# Passes unmodified MIDI data from an input port to an output port.  If
+# arguments are given, then the input and output ports will be connected to
+# other MIDI ports with the given names.
+#
+# Example: ./bin/midi_thru.rb jack-keyboard:midi_out zynaddsubfx:midi_input
+
+require 'bundler/setup'
+require 'mb-sound-jackffi'
+
+jack = MB::Sound::JackFFI[]
+
+input = jack.input(port_type: :midi, port_names: ['midi_in'], connect: ARGV[0])
+output = jack.output(port_type: :midi, port_names: ['midi_out'], connect: ARGV[1])
+
+loop do
+  event = input.read
+  puts event[0].bytes.inspect
+  output.write(event)
+end

--- a/lib/mb/sound/jack_ffi.rb
+++ b/lib/mb/sound/jack_ffi.rb
@@ -357,7 +357,9 @@ module MB
 
       # This is generally for internal use by the JackFFI::Input class.
       #
-      # Reads one buffer_size chunk of data for the given Array of port IDs.
+      # For audio, reads one buffer_size chunk of data for the given Array of
+      # port IDs.  For MIDI, reads one raw MIDI event as a String (which may
+      # contain multiple MIDI messages) for each port.
       def read_ports(ports)
         raise "JACK connection is closed" unless @run
 

--- a/lib/mb/sound/jack_ffi.rb
+++ b/lib/mb/sound/jack_ffi.rb
@@ -1,6 +1,5 @@
 require 'forwardable'
 require 'numo/narray'
-require 'nibbler'
 
 require_relative 'jack_ffi/jack'
 require_relative 'jack_ffi/input'
@@ -88,8 +87,6 @@ module MB
           JackPortIsInput: 1,
           JackPortIsOutput: 1,
         }
-
-        @midi_nibbler = Nibbler.new
 
         @init_mutex = Mutex.new
 
@@ -511,17 +508,11 @@ module MB
               queue.push(Numo::SFloat.from_binary(buf.read_bytes(frames * 4)), true)
 
             when Jack::MIDI_TYPE
-              @midi_nibbler.clear_buffer
-
               Jack.jack_midi_get_event_count(buf).times do |t|
                 event = Jack::JackMidiEvent.new
                 result = Jack.jack_midi_event_get(event, buf, t)
                 # TODO: push time with events
-                if result == 0
-                  events = @midi_nibbler.parse(event.data.bytes)
-                  events = [events] unless events.is_a?(Array)
-                  queue.push(events)
-                end
+                queue.push(event.data) if result == 0
               end
 
             else

--- a/lib/mb/sound/jack_ffi/input.rb
+++ b/lib/mb/sound/jack_ffi/input.rb
@@ -67,7 +67,7 @@ module MB
           case client_name_or_ports
           when String
             raise 'Client name to connect must not include a colon' if client_name_or_ports.include?(':')
-            new_ports = @jack_ffi.find_ports("^#{client_name_or_ports}:", flags: :JackPortIsOutput)
+            new_ports = @jack_ffi.find_ports("^#{client_name_or_ports}:", output: true)
 
           when Array
             new_ports = client_name_or_ports

--- a/lib/mb/sound/jack_ffi/input.rb
+++ b/lib/mb/sound/jack_ffi/input.rb
@@ -26,7 +26,17 @@ module MB
           @jack_ffi.remove(self)
         end
 
-        # Reads one #buffer_size buffer of frames as an Array of Numo::SFloat.
+        # For an audio input, reads one #buffer_size buffer of frames as an
+        # Array of Numo::SFloat.
+        #
+        # For a MIDI input, reads one MIDI event for each port as an Array of
+        # Strings.  MIDI events may arrive faster or slower than audio buffers.
+        # It is recommended to create only a single MIDI port per Input object
+        # for this reason, as this method blocks until *every* port has data.
+        #
+        # This method blocks until data is available for every port (FIXME:
+        # this doesn't work well for MIDI if it will be used in an audio loop).
+        #
         # Any frame count parameter is ignored, as JACK operates in lockstep with
         # a fixed buffer size.  The returned Array will have one element for each
         # input port.

--- a/lib/mb/sound/jack_ffi/jack.rb
+++ b/lib/mb/sound/jack_ffi/jack.rb
@@ -126,6 +126,9 @@ module MB
         attach_function :jack_midi_event_write, [:pointer, :jack_nframes_t, :pointer, :size_t], :int
         attach_function :jack_midi_get_lost_event_count, [:pointer], :uint32_t
 
+        # Time functions
+        attach_function :jack_last_frame_time, [:jack_client], :jack_nframes_t
+
         # Other functions
         attach_function :jack_free, [:pointer], :void
       end

--- a/lib/mb/sound/jack_ffi/output.rb
+++ b/lib/mb/sound/jack_ffi/output.rb
@@ -26,8 +26,9 @@ module MB
           @jack_ffi.remove(self)
         end
 
-        # Writes the given Array of data (Numo::SFloat recommended).  The Array
-        # should contain one element for each output port.
+        # Writes the given Array of data arrays (Numo::SFloat recommended for
+        # audio ports).  The Array should contain one element for each output
+        # port.
         def write(data)
           @jack_ffi.write_ports(@ports, data)
         end

--- a/lib/mb/sound/jack_ffi/output.rb
+++ b/lib/mb/sound/jack_ffi/output.rb
@@ -56,7 +56,7 @@ module MB
           case client_name_or_ports
           when String
             raise 'Client name to connect must not include a colon' if client_name_or_ports.include?(':')
-            new_ports = @jack_ffi.find_ports("^#{client_name_or_ports}:", flags: :JackPortIsInput)
+            new_ports = @jack_ffi.find_ports("^#{client_name_or_ports}:", input: true)
 
           when Array
             new_ports = client_name_or_ports

--- a/mb-sound-jackffi.gemspec
+++ b/mb-sound-jackffi.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'numo-narray', '~> 0.9.1'
   spec.add_runtime_dependency 'ffi', '~> 1.13.0'
+  spec.add_runtime_dependency 'midi-nibbler', '~> 0.2.4'
 end

--- a/mb-sound-jackffi.gemspec
+++ b/mb-sound-jackffi.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'numo-narray', '~> 0.9.1'
   spec.add_runtime_dependency 'ffi', '~> 1.13.0'
-  spec.add_runtime_dependency 'midi-nibbler', '~> 0.2.4'
 end

--- a/mb-sound-jackffi.gemspec
+++ b/mb-sound-jackffi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "mb-sound-jackffi"
-  spec.version       = '0.0.5.usegit'
+  spec.version       = '0.0.6.usegit'
   spec.authors       = ["Mike Bourgeous"]
   spec.email         = ["mike@mikebourgeous.com"]
 


### PR DESCRIPTION
This PR adds MIDI I/O port support and two example scripts, so that MIDI data can be sent and received via JACK.