### PR TITLE
Add environment variables to control client name and connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ be required for your system:
 
 ```bash
 # Debian-/Ubuntu-based Linux (macOS/Arch/CentOS will differ)
-sudo apt-get install libffi-dev
+sudo apt-get install libffi-dev libjack-jackd2-dev
 ```
 
 Then you'll want to install Ruby 2.7.2 or newer (I recommend

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ input or output ports on the JACK client.
 require 'mb-sound-jackffi' # Or 'mb/sound/jack_ffi'
 
 # Enjoy silence
-out = MB::Sound::JackFFI[client_name: 'my app'].output(port_names: ['left', 'right'], connect: :physical)
+out = MB::Sound::JackFFI['my app'].output(port_names: ['left', 'right'], connect: :physical)
 loop do
   out.write([Numo::SFloat.zeros(out.buffer_size)] * out.channels)
 end

--- a/bin/invert.rb
+++ b/bin/invert.rb
@@ -8,7 +8,7 @@ require 'mb-sound-jackffi'
 channels = ARGV[0]&.to_i || 2
 puts "Running with #{channels} channels"
 
-jack = MB::Sound::JackFFI[client_name: 'invert']
+jack = MB::Sound::JackFFI['invert']
 
 input = jack.input(channels: channels)
 output = jack.output(channels: channels)

--- a/bin/meter.rb
+++ b/bin/meter.rb
@@ -6,7 +6,7 @@
 require "bundler/setup"
 require 'mb-sound-jackffi'
 
-jack = MB::Sound::JackFFI[client_name: File.basename($0)]
+jack = MB::Sound::JackFFI[File.basename($0)]
 input = jack.input(connect: ARGV[0] || :physical)
 
 cols = ENV['COLUMNS']&.to_i || 80

--- a/bin/passthrough.rb
+++ b/bin/passthrough.rb
@@ -7,7 +7,7 @@ require 'mb-sound-jackffi'
 channels = ARGV[0]&.to_i || 2
 puts "Running with #{channels} channels"
 
-jack = MB::Sound::JackFFI[client_name: 'passthrough']
+jack = MB::Sound::JackFFI['passthrough']
 
 input = jack.input(channels: channels)
 output = jack.output(channels: channels)

--- a/lib/mb/sound/jack_ffi.rb
+++ b/lib/mb/sound/jack_ffi.rb
@@ -55,7 +55,7 @@ module MB
       #
       # The JACKFFI_CLIENT_NAME environment variable may be used to override the
       # default auto-generated client name.
-      def self.[](client_name: nil, server_name: nil)
+      def self.[](client_name = nil, server_name: nil)
         client_name ||= ENV['JACKFFI_CLIENT_NAME'] || File.basename($0).gsub(':', '_')
         @instances ||= {}
         @instances[name] ||= new(client_name: client_name, server_name: server_name)

--- a/lib/mb/sound/jack_ffi/input.rb
+++ b/lib/mb/sound/jack_ffi/input.rb
@@ -1,8 +1,8 @@
 module MB
   module Sound
     class JackFFI
-      # Returned by JackFFI#input.  E.g. use JackFFI[client_name: 'my
-      # client'].input(channels: 2) to get two input ports on the client.
+      # Returned by JackFFI#input.  E.g. use JackFFI['my client'].input(channels: 2)
+      # to get two input ports on the client.
       class Input
         extend Forwardable
 

--- a/lib/mb/sound/jack_ffi/output.rb
+++ b/lib/mb/sound/jack_ffi/output.rb
@@ -1,8 +1,8 @@
 module MB
   module Sound
     class JackFFI
-      # Returned by JackFFI#output.  E.g. use JackFFI[client_name: 'my
-      # client'].output(channels: 2) to get two output ports on the client.
+      # Returned by JackFFI#output.  E.g. use JackFFI['my client'].output(channels: 2)
+      # to get two output ports on the client.
       class Output
         extend Forwardable
 

--- a/mb-sound-jackffi.gemspec
+++ b/mb-sound-jackffi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "mb-sound-jackffi"
-  spec.version       = '0.0.9.usegit'
+  spec.version       = '0.0.10.usegit'
   spec.authors       = ["Mike Bourgeous"]
   spec.email         = ["mike@mikebourgeous.com"]
 


### PR DESCRIPTION
This PR adds support for JACKFFI_CLIENT_NAME, JACKFFI_INPUT_CONNECT, and JACKFFI_OUTPUT_CONNECT environment variables to control client name, input port connections, and output port connections, respectively.  These are documented in the JackFFI class docs and `#input` and `#output` method docs.

The `JackFFI[]` method signature was also changed in a breaking way, to make setting a client name easier.  This is okay because this is a pre-release gem.

## Testing

```bash
$ JACKFFI_INPUT_CONNECT=zynaddsubfx JACKFFI_OUTPUT_CONNECT=system bin/invert.rb 
Running with 2 channels
```

![image](https://user-images.githubusercontent.com/5015814/107425912-7399c380-6ad4-11eb-98d3-7f82c608754d.png)
