### PR TITLE
[Breaking] Add MIDI event timestamps

### DIFF
--- a/lib/mb/sound/jack_ffi.rb
+++ b/lib/mb/sound/jack_ffi.rb
@@ -638,7 +638,7 @@ module MB
               Jack.jack_midi_get_event_count(buf).times do |t|
                 event = Jack::JackMidiEvent.new
                 result = Jack.jack_midi_event_get(event, buf, t)
-                queue.push([event.time, event.data]) if result == 0
+                queue.push([event.time / @sample_rate, event.data]) if result == 0
               end
 
             else

--- a/lib/mb/sound/jack_ffi.rb
+++ b/lib/mb/sound/jack_ffi.rb
@@ -635,10 +635,15 @@ module MB
               queue.push(Numo::SFloat.from_binary(buf.read_bytes(frames * 4)), true)
 
             when Jack::MIDI_TYPE
-              Jack.jack_midi_get_event_count(buf).times do |t|
-                event = Jack::JackMidiEvent.new
-                result = Jack.jack_midi_event_get(event, buf, t)
-                queue.push([event.time / @sample_rate, event.data]) if result == 0
+              count = Jack.jack_midi_get_event_count(buf)
+              if count > 0
+                events = Array.new(count) do |t|
+                  event = Jack::JackMidiEvent.new
+                  result = Jack.jack_midi_event_get(event, buf, t)
+                  [event.time / @sample_rate, event.data]
+                end
+
+                queue.push(events)
               end
 
             else

--- a/lib/mb/sound/jack_ffi.rb
+++ b/lib/mb/sound/jack_ffi.rb
@@ -71,6 +71,9 @@ module MB
 
       attr_reader :client_name, :server_name, :buffer_size, :sample_rate, :inputs, :outputs
 
+      # The time, in samples, at the start of the most recent frame/buffer.
+      attr_reader :current_frame
+
       # An optional object that responds to Logger-style methods like #info and
       # #error.
       attr_accessor :logger
@@ -109,6 +112,8 @@ module MB
         @init_mutex = Mutex.new
 
         @init_mutex.synchronize {
+          @current_frame = 0
+
           status = Jack::JackStatusWrapper.new
           @client = Jack.jack_client_open(
             client_name,
@@ -607,7 +612,7 @@ module MB
         @init_mutex&.synchronize {
           return unless @run && @client && @input_ports && @output_ports
 
-          start_frame = Jack.jack_last_frame_time(@client)
+          @current_frame = Jack.jack_last_frame_time(@client)
 
           @input_ports.each do |name, port_info|
             # FIXME: Avoid allocation in this function; use a buffer pool or something
@@ -633,8 +638,7 @@ module MB
               Jack.jack_midi_get_event_count(buf).times do |t|
                 event = Jack::JackMidiEvent.new
                 result = Jack.jack_midi_event_get(event, buf, t)
-                # TODO: push time with events
-                queue.push(event.data) if result == 0
+                queue.push([event.time, event.data]) if result == 0
               end
 
             else

--- a/lib/mb/sound/jack_ffi.rb
+++ b/lib/mb/sound/jack_ffi.rb
@@ -640,7 +640,7 @@ module MB
                 events = Array.new(count) do |t|
                   event = Jack::JackMidiEvent.new
                   result = Jack.jack_midi_event_get(event, buf, t)
-                  [event.time / @sample_rate, event.data]
+                  [event.time.to_f / @sample_rate, event.data]
                 end
 
                 queue.push(events)

--- a/lib/mb/sound/jack_ffi/input.rb
+++ b/lib/mb/sound/jack_ffi/input.rb
@@ -14,10 +14,12 @@ module MB
         # For an audio input, reads one #buffer_size buffer of frames as an
         # Array of Numo::SFloat.
         #
-        # For a MIDI input, reads one MIDI event for each port as an Array of
-        # [time: Float, data: String].  The time here is the offset within the
-        # audio buffer.  It is recommended to create only a single MIDI port
-        # per Input object, as this method blocks until *every* port has data.
+        # For a MIDI input, reads an Array of MIDI events for each port, with
+        # each event an Array of [time: Float, data: String].  The time here is
+        # the offset within the audio buffer.
+        #
+        # It is recommended to create only a single MIDI port per Input object,
+        # as this method blocks until *every* port has data.
         #
         # If +:blocking+ is true (the default), this method blocks until data
         # is available for every port.  If false, nil will be returned for any

--- a/lib/mb/sound/jack_ffi/input.rb
+++ b/lib/mb/sound/jack_ffi/input.rb
@@ -15,10 +15,9 @@ module MB
         # Array of Numo::SFloat.
         #
         # For a MIDI input, reads one MIDI event for each port as an Array of
-        # [frame: Integer, data: String].  The frame here is the sample offset
-        # within the audio buffer.  It is recommended to create only a single
-        # MIDI port per Input object, as this method blocks until *every* port
-        # has data.
+        # [time: Float, data: String].  The time here is the offset within the
+        # audio buffer.  It is recommended to create only a single MIDI port
+        # per Input object, as this method blocks until *every* port has data.
         #
         # If +:blocking+ is true (the default), this method blocks until data
         # is available for every port.  If false, nil will be returned for any

--- a/lib/mb/sound/jack_ffi/input.rb
+++ b/lib/mb/sound/jack_ffi/input.rb
@@ -15,9 +15,10 @@ module MB
         # Array of Numo::SFloat.
         #
         # For a MIDI input, reads one MIDI event for each port as an Array of
-        # Strings.  MIDI events may arrive faster or slower than audio buffers.
-        # It is recommended to create only a single MIDI port per Input object
-        # for this reason, as this method blocks until *every* port has data.
+        # [frame: Integer, data: String].  The frame here is the sample offset
+        # within the audio buffer.  It is recommended to create only a single
+        # MIDI port per Input object, as this method blocks until *every* port
+        # has data.
         #
         # If +:blocking+ is true (the default), this method blocks until data
         # is available for every port.  If false, nil will be returned for any

--- a/mb-sound-jackffi.gemspec
+++ b/mb-sound-jackffi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "mb-sound-jackffi"
-  spec.version       = '0.1.0.usegit'
+  spec.version       = '0.2.0.usegit'
   spec.authors       = ["Mike Bourgeous"]
   spec.email         = ["mike@mikebourgeous.com"]
 


### PR DESCRIPTION
This returns timestamps with individual MIDI events, allowing sub-buffer accuracy in MIDI-controlled mb-sound synthesizers.

Blocks https://github.com/mike-bourgeous/mb-sound/pull/60.